### PR TITLE
Bug fix for XBox controllers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,24 @@ This is a quick hack to get [Google Stadia](https://stadia.google.com/) running 
 
 The `ChromiumForStadia.apk` was created using the following steps:
 
-1. A stock version of Chromium for Android was built using the [official guide](https://chromium.googlesource.com/chromium/src/+/master/docs/android_build_instructions.md) @ 3333b9d62d44b68615a6f40c429d7f93cbc71781 from 4/13/2020.
+1. A stock version of Chromium for Android was built using the [official guide](https://chromium.googlesource.com/chromium/src/+/master/docs/android_build_instructions.md) @ d8ee3103df6690863af52dad05b4fafa9d11f8ee from 3/08/2021, version 89.0.4389.86.
 1. The changes in `chromiumForStadia.diff` were made to the stock source. The core changes are:
    * Modifying `chrome/android/java/AndroidManifest.xml`. This allows the app to show up on [Android TV devices](https://developer.android.com/training/tv/start/start).
    * Modifying `FullscreenHtmlApiHandler.applyEnterFullscreenUIFlags`. This fakes `{navigationUI: "hide"}` and avoids https://bugs.chromium.org/p/chromium/issues/detail?id=933436#c7.
    * Modifying `device/gamepad/gamepad_platform_data_fetcher_android.c` to mark any controller's `mapping` as `standard`. Without this, Stadia doesn't detect the controller.
    * Modifying `third_party/blink/renderer/core/dom/document_or_shadow_root.h` to perform the equivalent of `document.pointerLockElement = document.fullscreenElement`. This hack gets around the fact that the [Pointer Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API) doesn't work as Stadia expects on mobile devices.
+   * Modifying `chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java` to replace BACK button with SELECT. This fixes a bug where xbox controller SELECT button is read as a back button which exits stadia instead of being processed by the game. This is only because Oculus Quest runs an old version of android with this bug present.
 
 With these changes, going to [stadia.google.com](https://stadia.google.com) in this app and enabling **Desktop Mode** will allow you to stream Stadia to the browser on Android devices. You can also use unsupported USB & Bluetooth controllers with the browser. You can test your gamepad at [html5gamepad.com/](https://html5gamepad.com/).
 
-This app was tested on a Pixel 4 & Oculus Quest using an [ASUS Bluetooth Gamepad](https://www.asus.com/us/Home-Entertainment/Gamepad-TV500BG/), PS4 Dualshock, X-Box One controller, and the official Stadia controller via USB C.
+This app was tested on a Pixel 4 & Oculus Quest using an [ASUS Bluetooth Gamepad](https://www.asus.com/us/Home-Entertainment/Gamepad-TV500BG/), PS4 Dualshock, X-Box One controller, X-Box Elite 2 controller, and the official Stadia controller via USB C.
 
 Note that this app is not officially supported by Google nor Oculus and may unexpectedly break at any point.
 [This reddit post](https://www.reddit.com/r/Stadia/comments/e11897/how_to_get_stadia_running_in_android_chrome_on/) has some more notes on how to get Stadia working in the browser without using a custom app. The app was just meant to streamline those instructions.
 
 ## Release notes
 
+*  3/13/2021 - Pull in upstream changes. Fix XBox select button.
 *  4/19/2020 - Pull in upstream changes. Fixes XBox controller support and improves fullscreen UI.
 *  1/ 4/2020 - Pull in upstream changes. Remove localstorage hack. Remove controller mapping hack since the changes were merged upstream.
 * 12/ 9/2019 - Improve support for PS4 controllers on older OSes.

--- a/chromiumForStadia.diff
+++ b/chromiumForStadia.diff
@@ -1,8 +1,8 @@
 diff --git a/chrome/android/java/AndroidManifest.xml b/chrome/android/java/AndroidManifest.xml
-index 853ec785e2fe..67630c54ec30 100644
+index 5e699b5e3dca..c2f7700232b5 100644
 --- a/chrome/android/java/AndroidManifest.xml
 +++ b/chrome/android/java/AndroidManifest.xml
-@@ -17,6 +17,7 @@ by a child template that "extends" this file.
+@@ -22,6 +22,7 @@ by a child template that "extends" this file.
      <!-- android:versionCode and android:versionName is set through gyp. See build/common.gypi -->
  
      <uses-feature android:glEsVersion="0x00020000" />
@@ -10,42 +10,79 @@ index 853ec785e2fe..67630c54ec30 100644
  
      <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
      <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-@@ -127,6 +128,7 @@ by a child template that "extends" this file.
-          Java heap limit (32Mb on Nexus S, 48Mb on Xoom). -->
-     <application android:name="{% block application_name %}org.chromium.chrome.browser.ChromeApplication{% endblock %}"
+@@ -160,6 +161,7 @@ by a child template that "extends" this file.
+           {%- endif -%}
+           {% endblock %}"
          android:icon="@drawable/ic_launcher"
 +        android:banner="@drawable/ic_launcher"
          android:roundIcon="@drawable/ic_launcher_round"
          android:label="{% block application_label %}@string/app_name{% endblock %}"
          android:largeHeap="false"
-@@ -213,6 +215,7 @@ by a child template that "extends" this file.
+@@ -200,6 +202,7 @@ by a child template that "extends" this file.
              android:exported="true">
              <intent-filter>
                  <action android:name="android.intent.action.MAIN" />
 +                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
                  <category android:name="android.intent.category.NOTIFICATION_PREFERENCES" />
-                 {% if enable_vr == "true" %}
-                 <category android:name="com.google.intent.category.DAYDREAM" />
+             </intent-filter>
+             <!-- Matches the common case of intents with no MIME type.
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+index 696db6798f98..7e64a4ce4f6c 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+@@ -2239,6 +2239,18 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
+
+     @Override
+     public boolean dispatchKeyEvent(KeyEvent event) {
++        if (event.getKeyCode() == 4) {
++                event = new KeyEvent (event.getDownTime(),
++                                      event.getEventTime(),
++                                      event.getAction(),
++                                      KeyEvent.KEYCODE_BUTTON_SELECT, // event.getCode(),
++                                      event.getRepeatCount(),
++                                      event.getMetaState(),
++                                      event.getDeviceId(),
++                                      316, // event.getScancode(),
++                                      event.getFlags(),
++                                      event.getSource());
++        }
+         Boolean result = KeyboardShortcuts.dispatchKeyEvent(event, this, mUIWithNativeInitialized);
+         return result != null ? result : super.dispatchKeyEvent(event);
+     }
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandler.java b/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandler.java
-index 274d82704979..9f2956e25f39 100644
+index 7e1cb26eedfb..ed196c455bb9 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandler.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandler.java
-@@ -395,8 +395,8 @@ public class FullscreenHtmlApiHandler {
+@@ -571,8 +571,7 @@ public class FullscreenHtmlApiHandler implements ActivityStateListener, WindowFo
       * @return fullscreen flags to be applied to system UI visibility.
       */
      private int applyEnterFullscreenUIFlags(int systemUiVisibility) {
 -        boolean showNavigationBar =
 -                mFullscreenOptions != null ? mFullscreenOptions.showNavigationBar() : false;
 +        boolean showNavigationBar = false;
-+                //mFullscreenOptions != null ? mFullscreenOptions.showNavigationBar() : false;
          int flags = SYSTEM_UI_FLAG_FULLSCREEN;
          flags |= View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
          if (!showNavigationBar) {
+diff --git a/device/gamepad/gamepad_data_fetcher.cc b/device/gamepad/gamepad_data_fetcher.cc
+index c47b76bf9e20..3fd5b38702c6 100644
+--- a/device/gamepad/gamepad_data_fetcher.cc
++++ b/device/gamepad/gamepad_data_fetcher.cc
+@@ -97,8 +97,8 @@ void GamepadDataFetcher::UpdateGamepadStrings(const std::string& product_name,
+
+   // Set GamepadMapping::kStandard if the gamepad has a standard mapping, or
+   // GamepadMapping::kNone otherwise.
+-  pad.mapping =
+-      has_standard_mapping ? GamepadMapping::kStandard : GamepadMapping::kNone;
++  pad.mapping = GamepadMapping::kStandard;
++      // has_standard_mapping ? GamepadMapping::kStandard : GamepadMapping::kNone;
+ }
+
+ // static
 diff --git a/device/gamepad/gamepad_platform_data_fetcher_android.cc b/device/gamepad/gamepad_platform_data_fetcher_android.cc
-index 38a6cb45240d..29f971b78497 100644
+index 6eb0a7330fe2..77d8d78e737f 100644
 --- a/device/gamepad/gamepad_platform_data_fetcher_android.cc
 +++ b/device/gamepad/gamepad_platform_data_fetcher_android.cc
-@@ -98,7 +98,7 @@ static void JNI_GamepadList_SetGamepadData(
+@@ -99,7 +99,7 @@ static void JNI_GamepadList_SetGamepadData(
      base::android::ConvertJavaStringToUTF16(env, devicename, &gamepad_id);
      pad.SetID(gamepad_id);
  
@@ -55,23 +92,22 @@ index 38a6cb45240d..29f971b78497 100644
  
    pad.connected = true;
 diff --git a/third_party/blink/renderer/core/dom/document_or_shadow_root.h b/third_party/blink/renderer/core/dom/document_or_shadow_root.h
-index cfed2ae42a7f..23f184e010f1 100644
+index 5bb9914dc6d6..223d61296495 100644
 --- a/third_party/blink/renderer/core/dom/document_or_shadow_root.h
 +++ b/third_party/blink/renderer/core/dom/document_or_shadow_root.h
-@@ -72,6 +72,8 @@ class DocumentOrShadowRoot {
- 
+@@ -72,10 +72,11 @@ class DocumentOrShadowRoot {
+
    static Element* pointerLockElement(Document& document) {
      UseCounter::Count(document, WebFeature::kDocumentPointerLockElement);
+-    const Element* target = document.PointerLockElement();
+-    if (!target)
+-      return nullptr;
+-    return document.AdjustedElement(*target);
 +    return Fullscreen::FullscreenElementForBindingFrom(document);
-+    /*
-     const Element* target = document.PointerLockElement();
-     if (!target)
-       return nullptr;
-@@ -85,6 +87,7 @@ class DocumentOrShadowRoot {
-       return const_cast<Element*>(target);
-     }
-     return document.AdjustedElement(*target);
-+    */
++    // const Element* target = document.PointerLockElement();
++    // if (!target)
++    //   return nullptr;
++    // return document.AdjustedElement(*target);
    }
- 
+
    static Element* pointerLockElement(ShadowRoot& shadow_root) {


### PR DESCRIPTION
Hack to fix the select button on xbox controllers. This button triggers an event for the "Back" button instead of "Select" button on some versions of android, such as the one running on Oculus Quest. This change remaps the "Back" button press to the "Select" button press. The downside is if the user actually wants to press the back button they won't be able to do it.